### PR TITLE
add unitop

### DIFF
--- a/neqsim/process/measurement.py
+++ b/neqsim/process/measurement.py
@@ -1,0 +1,99 @@
+from neqsim import jNeqSim
+import jpype
+import jpype.imports
+from jpype import JImplements, JOverride
+
+
+# Ensure the JVM is started and neqsim is attached
+# Assuming you have already started the JVM with neqsim on the classpath
+# If not, you'll need to start it before this code
+
+@JImplements(jNeqSim.processSimulation.measurementDevice.MeasurementDeviceInterface) # Use the fully qualified class name directly from the jNeqSim package
+class measurement:
+    def __init__(self):
+        self.name = ""
+        self.unit = ""
+        self.maximumValue = None
+        self.minimumValue = None
+        self.logging = False
+        self.isOnlineSignal = False
+        self.isMeasuredPercentValue = False
+        self.isMeasuredValue = False
+
+    @JOverride # Add the missing 'equals' method
+    def equals(self, obj):
+      # Implement your equality logic here. 
+      # For example, you might compare the names of the objects:
+      if isinstance(obj, unitop):
+          return self.name == obj.name
+      return False
+
+    @JOverride # Implement the missing 'hashCode' method
+    def hashCode(self):
+        # Implement your hash code logic here. 
+        # A simple example is to return the hash of the object's name:
+        return hash(self.name)
+
+    @JOverride # Implement the missing 'displayResult' method
+    def displayResult(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getMeasuredValue' method
+    def getMeasuredValue(self):
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+
+
+    @JOverride # Implement the missing 'getOnlineSignal' method
+    def getOnlineSignal(self):
+        return 0.0  
+
+    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    def getMeasuredPercentValue(self):
+        return 0.0
+
+    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    def getUnit(self):
+        return self.unit    
+
+    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    def setUnit(self, unitl):
+        self.unit = unitl 
+
+    @JOverride # Implement the missing 'getMaximumValue' method
+    def getMaximumValue(self):
+        return self.maximumValue  
+
+    @JOverride # Implement the missing 'setMaximumValue' method
+    def setMaximumValue(self, val):
+      self.maximumValue = val
+    
+    @JOverride # Implement the missing 'getMinimumValue' method
+    def getMinimumValue(self):
+        return self.minimumValue  
+
+    @JOverride # Implement the missing 'setMinimumValue' method
+    def setMinimumValue(self, val):
+      self.minimumValue = val
+    
+    @JOverride # Implement the missing 'isLogging' method
+    def isLogging(self):
+      return self.logging  
+
+    @JOverride # Implement the missing 'setLogging' method
+    def setLogging(self, val):
+      self.logging = val
+    
+    @JOverride # Implement the missing 'isOnlineSignal' method
+    def isOnlineSignal(self):
+      return self.isOnlineSignal  
+
+    @JOverride
+    def getName(self):
+        return self.name
+
+    @JOverride
+    def setName(self, name):
+        self.name = name

--- a/neqsim/process/measurement.py
+++ b/neqsim/process/measurement.py
@@ -8,7 +8,10 @@ from jpype import JImplements, JOverride
 # Assuming you have already started the JVM with neqsim on the classpath
 # If not, you'll need to start it before this code
 
-@JImplements(jNeqSim.processSimulation.measurementDevice.MeasurementDeviceInterface) # Use the fully qualified class name directly from the jNeqSim package
+
+@JImplements(
+    jNeqSim.processSimulation.measurementDevice.MeasurementDeviceInterface
+)  # Use the fully qualified class name directly from the jNeqSim package
 class measurement:
     def __init__(self):
         self.name = ""
@@ -20,75 +23,74 @@ class measurement:
         self.isMeasuredPercentValue = False
         self.isMeasuredValue = False
 
-    @JOverride # Add the missing 'equals' method
+    @JOverride  # Add the missing 'equals' method
     def equals(self, obj):
-      # Implement your equality logic here. 
-      # For example, you might compare the names of the objects:
-      if isinstance(obj, unitop):
-          return self.name == obj.name
-      return False
+        # Implement your equality logic here.
+        # For example, you might compare the names of the objects:
+        if isinstance(obj, unitop):
+            return self.name == obj.name
+        return False
 
-    @JOverride # Implement the missing 'hashCode' method
+    @JOverride  # Implement the missing 'hashCode' method
     def hashCode(self):
-        # Implement your hash code logic here. 
+        # Implement your hash code logic here.
         # A simple example is to return the hash of the object's name:
         return hash(self.name)
 
-    @JOverride # Implement the missing 'displayResult' method
+    @JOverride  # Implement the missing 'displayResult' method
     def displayResult(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getMeasuredValue' method
+    @JOverride  # Implement the missing 'getMeasuredValue' method
     def getMeasuredValue(self):
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
 
-
-    @JOverride # Implement the missing 'getOnlineSignal' method
+    @JOverride  # Implement the missing 'getOnlineSignal' method
     def getOnlineSignal(self):
-        return 0.0  
+        return 0.0
 
-    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    @JOverride  # Implement the missing 'getMeasuredPercentValue' method
     def getMeasuredPercentValue(self):
         return 0.0
 
-    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    @JOverride  # Implement the missing 'getMeasuredPercentValue' method
     def getUnit(self):
-        return self.unit    
+        return self.unit
 
-    @JOverride # Implement the missing 'getMeasuredPercentValue' method
+    @JOverride  # Implement the missing 'getMeasuredPercentValue' method
     def setUnit(self, unitl):
-        self.unit = unitl 
+        self.unit = unitl
 
-    @JOverride # Implement the missing 'getMaximumValue' method
+    @JOverride  # Implement the missing 'getMaximumValue' method
     def getMaximumValue(self):
-        return self.maximumValue  
+        return self.maximumValue
 
-    @JOverride # Implement the missing 'setMaximumValue' method
+    @JOverride  # Implement the missing 'setMaximumValue' method
     def setMaximumValue(self, val):
-      self.maximumValue = val
-    
-    @JOverride # Implement the missing 'getMinimumValue' method
+        self.maximumValue = val
+
+    @JOverride  # Implement the missing 'getMinimumValue' method
     def getMinimumValue(self):
-        return self.minimumValue  
+        return self.minimumValue
 
-    @JOverride # Implement the missing 'setMinimumValue' method
+    @JOverride  # Implement the missing 'setMinimumValue' method
     def setMinimumValue(self, val):
-      self.minimumValue = val
-    
-    @JOverride # Implement the missing 'isLogging' method
-    def isLogging(self):
-      return self.logging  
+        self.minimumValue = val
 
-    @JOverride # Implement the missing 'setLogging' method
+    @JOverride  # Implement the missing 'isLogging' method
+    def isLogging(self):
+        return self.logging
+
+    @JOverride  # Implement the missing 'setLogging' method
     def setLogging(self, val):
-      self.logging = val
-    
-    @JOverride # Implement the missing 'isOnlineSignal' method
+        self.logging = val
+
+    @JOverride  # Implement the missing 'isOnlineSignal' method
     def isOnlineSignal(self):
-      return self.isOnlineSignal  
+        return self.isOnlineSignal
 
     @JOverride
     def getName(self):

--- a/neqsim/process/unitop.py
+++ b/neqsim/process/unitop.py
@@ -1,0 +1,18 @@
+import jpype
+import jpype.imports
+from jpype import JImplements, JOverride
+import numpy as np
+from neqsim import jNeqSim
+
+@JImplements(jNeqSim.util.NamedInterface) # Use the fully qualified class name directly from the jNeqSim package
+class unitop:
+    def __init__(self):
+        self.name = ""
+
+    @JOverride
+    def getName(self):
+        return self.name
+
+    @JOverride
+    def setName(self, name):
+        self.name = name

--- a/neqsim/process/unitop.py
+++ b/neqsim/process/unitop.py
@@ -8,7 +8,10 @@ from jpype import JImplements, JOverride
 # Assuming you have already started the JVM with neqsim on the classpath
 # If not, you'll need to start it before this code
 
-@JImplements(jNeqSim.processSimulation.processEquipment.ProcessEquipmentInterface) # Use the fully qualified class name directly from the jNeqSim package
+
+@JImplements(
+    jNeqSim.processSimulation.processEquipment.ProcessEquipmentInterface
+)  # Use the fully qualified class name directly from the jNeqSim package
 class unitop:
     def __init__(self):
         self.name = ""
@@ -20,217 +23,217 @@ class unitop:
     @JOverride
     def setName(self, name):
         self.name = name
-    
-    @JOverride # Add the missing 'equals' method
+
+    @JOverride  # Add the missing 'equals' method
     def equals(self, obj):
-        # Implement your equality logic here. 
+        # Implement your equality logic here.
         # For example, you might compare the names of the objects:
         if isinstance(obj, unitop):
             return self.name == obj.name
         return False
-    
-    @JOverride # Implement the missing 'hashCode' method
+
+    @JOverride  # Implement the missing 'hashCode' method
     def hashCode(self):
-        # Implement your hash code logic here. 
+        # Implement your hash code logic here.
         # A simple example is to return the hash of the object's name:
         return hash(self.name)
 
-    @JOverride # Implement the missing 'setController' method
+    @JOverride  # Implement the missing 'setController' method
     def setController(self, controller):
         # Add the logic for setting the controller here.
         # This will depend on how you want to handle controllers in your 'unitop' class.
         pass  # Replace 'pass' with your implementation
 
-    @JOverride # Implement the missing 'getController' method
+    @JOverride  # Implement the missing 'getController' method
     def getController(self):
         # Add logic to return the controller associated with this unitop
         # For now, we'll just return None
         return None  # Replace with your actual controller retrieval logic
 
-    @JOverride # Implement the missing 'getPressure' method
+    @JOverride  # Implement the missing 'getPressure' method
     def getPressure(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'setPressure' method
+    @JOverride  # Implement the missing 'setPressure' method
     def setPressure(self, pressure):
-        pass  # Replace 'pass' with your implementation   
+        pass  # Replace 'pass' with your implementation
 
-    @JOverride # Implement the missing 'getEntropyProduction' method
+    @JOverride  # Implement the missing 'getEntropyProduction' method
     def getEntropyProduction(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculation
-        
-    @JOverride # Implement the missing 'getMassBalance' method
+
+    @JOverride  # Implement the missing 'getMassBalance' method
     def getMassBalance(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculation
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getExergyChange(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation   
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def runConditionAnalysis(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getMechanicalDesign(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation       
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getSpecification(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setSpecification(self, spec):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def reportResults(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getThermoSystem(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getConditionAnalysisMessage(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getResultTable(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def toJson(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getReport_json(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+        # Add the logic to calculate or retrieve the pressure.
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def displayResult(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setRegulatorOutSignal(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def run(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setTime(self, time):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
-        pass# eturn 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        pass  # eturn 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getTime(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+        # Add the logic to calculate or retrieve the pressure.
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def solved(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return True  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure.     
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+        # Add the logic to calculate or retrieve the pressure.
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getCalculationIdentifier(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setCalculationIdentifier(self, idf):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         pass  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
-    
-    @JOverride # Implement the missing 'getExergyChange' method
+        # Add the logic to calculate or retrieve the pressure.
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def getCalculateSteadyState(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setCalculateSteadyState(self, idf):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         pass  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def increaseTime(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
-     
-    @JOverride # Implement the missing 'getExergyChange' method
+        # Add the logic to calculate or retrieve the pressure.
+
+    @JOverride  # Implement the missing 'getExergyChange' method
     def setRunInSteps(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def isRunInSteps(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
 
-    @JOverride # Implement the missing 'getExergyChange' method
+    @JOverride  # Implement the missing 'getExergyChange' method
     def run_step(self):
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.
         # This will depend on how pressure is handled in your 'unitop' class.
         return 0.0  # Replace 0.0 with the actual pressure value or calculatio
-        # Add the logic to calculate or retrieve the pressure. 
+        # Add the logic to calculate or retrieve the pressure.

--- a/neqsim/process/unitop.py
+++ b/neqsim/process/unitop.py
@@ -1,10 +1,13 @@
+from neqsim import jNeqSim
 import jpype
 import jpype.imports
 from jpype import JImplements, JOverride
-import numpy as np
-from neqsim import jNeqSim
 
-@JImplements(jNeqSim.util.NamedInterface) # Use the fully qualified class name directly from the jNeqSim package
+# Ensure the JVM is started and neqsim is attached
+# Assuming you have already started the JVM with neqsim on the classpath
+# If not, you'll need to start it before this code
+
+@JImplements(jNeqSim.processSimulation.processEquipment.ProcessEquipmentInterface) # Use the fully qualified class name directly from the jNeqSim package
 class unitop:
     def __init__(self):
         self.name = ""
@@ -16,3 +19,217 @@ class unitop:
     @JOverride
     def setName(self, name):
         self.name = name
+    
+    @JOverride # Add the missing 'equals' method
+    def equals(self, obj):
+        # Implement your equality logic here. 
+        # For example, you might compare the names of the objects:
+        if isinstance(obj, unitop):
+            return self.name == obj.name
+        return False
+    
+    @JOverride # Implement the missing 'hashCode' method
+    def hashCode(self):
+        # Implement your hash code logic here. 
+        # A simple example is to return the hash of the object's name:
+        return hash(self.name)
+
+    @JOverride # Implement the missing 'setController' method
+    def setController(self, controller):
+        # Add the logic for setting the controller here.
+        # This will depend on how you want to handle controllers in your 'unitop' class.
+        pass  # Replace 'pass' with your implementation
+
+    @JOverride # Implement the missing 'getController' method
+    def getController(self):
+        # Add logic to return the controller associated with this unitop
+        # For now, we'll just return None
+        return None  # Replace with your actual controller retrieval logic
+
+    @JOverride # Implement the missing 'getPressure' method
+    def getPressure(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
+
+    @JOverride # Implement the missing 'setPressure' method
+    def setPressure(self, pressure):
+        pass  # Replace 'pass' with your implementation   
+
+    @JOverride # Implement the missing 'getEntropyProduction' method
+    def getEntropyProduction(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
+        
+    @JOverride # Implement the missing 'getMassBalance' method
+    def getMassBalance(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getExergyChange(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation   
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def runConditionAnalysis(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getMechanicalDesign(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation       
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getSpecification(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setSpecification(self, spec):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def reportResults(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculation 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getThermoSystem(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getConditionAnalysisMessage(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getResultTable(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def toJson(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getReport_json(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def displayResult(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setRegulatorOutSignal(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def run(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setTime(self, time):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        pass# eturn 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getTime(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def solved(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return True  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure.     
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getCalculationIdentifier(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setCalculationIdentifier(self, idf):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        pass  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+    
+    @JOverride # Implement the missing 'getExergyChange' method
+    def getCalculateSteadyState(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setCalculateSteadyState(self, idf):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        pass  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def increaseTime(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+     
+    @JOverride # Implement the missing 'getExergyChange' method
+    def setRunInSteps(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def isRunInSteps(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 
+
+    @JOverride # Implement the missing 'getExergyChange' method
+    def run_step(self):
+        # Add the logic to calculate or retrieve the pressure. 
+        # This will depend on how pressure is handled in your 'unitop' class.
+        return 0.0  # Replace 0.0 with the actual pressure value or calculatio
+        # Add the logic to calculate or retrieve the pressure. 

--- a/tests/process/test_measurement.py
+++ b/tests/process/test_measurement.py
@@ -10,18 +10,19 @@ from neqsim.thermo import fluid
 from neqsim import jNeqSim
 from jpype import JImplements, JOverride
 
+
 class ExampleMeasurement(measurement):
     def __init__(self):
         super().__init__()
         self.name = ""
-    
+
     def setInputStream(self, stream):
         self.inputstream = stream
         self.outputstream = stream.clone()
 
     def getMeasuredValue(self):
         return self.inputstream.getPressure("psia")
-    
+
 
 def test_addPythonUnitOp():
     fluid1 = fluid("srk")  # create a fluid using the SRK-EoS
@@ -33,9 +34,9 @@ def test_addPythonUnitOp():
 
     stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)
     stream1.setFlowRate(30000, "kg/hr")
-    
+
     meas1 = ExampleMeasurement()
-    meas1.setName('example measurement 1')
+    meas1.setName("example measurement 1")
     meas1.setInputStream(stream1)
 
     oilprocess = jNeqSim.processSimulation.processSystem.ProcessSystem()
@@ -43,5 +44,4 @@ def test_addPythonUnitOp():
     oilprocess.add(meas1)
     oilprocess.run()
 
-    assert stream1.getPressure("psia")==meas1.getMeasuredValue()
-
+    assert stream1.getPressure("psia") == meas1.getMeasuredValue()

--- a/tests/process/test_measurement.py
+++ b/tests/process/test_measurement.py
@@ -1,0 +1,47 @@
+from neqsim.process.measurement import measurement
+from neqsim.process.processTools import (
+    pump,
+    stream,
+    clearProcess,
+    runProcess,
+    pumpChart,
+)
+from neqsim.thermo import fluid
+from neqsim import jNeqSim
+from jpype import JImplements, JOverride
+
+class ExampleMeasurement(measurement):
+    def __init__(self):
+        super().__init__()
+        self.name = ""
+    
+    def setInputStream(self, stream):
+        self.inputstream = stream
+        self.outputstream = stream.clone()
+
+    def getMeasuredValue(self):
+        return self.inputstream.getPressure("psia")
+    
+
+def test_addPythonUnitOp():
+    fluid1 = fluid("srk")  # create a fluid using the SRK-EoS
+    fluid1.setTemperature(30.0, "C")
+    fluid1.setPressure(1.0, "bara")
+    fluid1.addComponent("n-pentane", 1.0, "kg/sec")
+    fluid1.addComponent("n-hexane", 1.0, "kg/sec")
+    fluid1.setMixingRule(2)
+
+    stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)
+    stream1.setFlowRate(30000, "kg/hr")
+    
+    meas1 = ExampleMeasurement()
+    meas1.setName('example measurement 1')
+    meas1.setInputStream(stream1)
+
+    oilprocess = jNeqSim.processSimulation.processSystem.ProcessSystem()
+    oilprocess.add(stream1)
+    oilprocess.add(meas1)
+    oilprocess.run()
+
+    assert stream1.getPressure("psia")==meas1.getMeasuredValue()
+

--- a/tests/process/test_unitop.py
+++ b/tests/process/test_unitop.py
@@ -1,5 +1,64 @@
 from neqsim.process.unitop import unitop
+from neqsim.process.processTools import (
+    pump,
+    stream,
+    clearProcess,
+    runProcess,
+    pumpChart,
+)
+from neqsim.thermo import fluid
+from neqsim import jNeqSim
+from jpype import JImplements, JOverride
 
-def test_pump():
-    uop = unitop()
-    assert True
+class ExampleCompressor(unitop):
+    def __init__(self):
+        super().__init__()
+        self.name = ""
+        self.inputstream = None
+        self.outputstream = None
+    
+    def setInputStream(self, stream):
+        self.inputstream = stream
+        self.outputstream = stream.clone()
+
+    def getOutputStream(self):
+        return self.outputstream
+    
+    @JOverride
+    def run(self):
+        fluid2 = self.inputstream.getFluid().clone()
+        fluid2.setPressure(fluid2.getPressure()*2.0)
+        self.outputstream.setFluid(fluid2)
+        self.outputstream.run()
+
+def test_addPythonUnitOp():
+    fluid1 = fluid("srk")  # create a fluid using the SRK-EoS
+    fluid1.setTemperature(30.0, "C")
+    fluid1.setPressure(1.0, "bara")
+    fluid1.addComponent("n-pentane", 1.0, "kg/sec")
+    fluid1.addComponent("n-hexane", 1.0, "kg/sec")
+    fluid1.setMixingRule(2)
+
+    stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)
+    stream1.setFlowRate(30000, "kg/hr")
+    stream1.run()
+    
+    uop = ExampleCompressor()
+    uop.setName('example operation 1')
+    uop.setInputStream(stream1)
+    uop.run()
+
+    stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(uop.getOutputStream())
+    stream2.run()
+
+    assert stream2.getPressure()==2*stream1.getPressure()
+
+    
+    oilprocess = jNeqSim.processSimulation.processSystem.ProcessSystem()
+    oilprocess.add(stream1)
+    oilprocess.add(uop)
+    oilprocess.add(stream2)
+
+    oilprocess.run()
+
+    assert stream2.getPressure()==2*stream1.getPressure()

--- a/tests/process/test_unitop.py
+++ b/tests/process/test_unitop.py
@@ -10,26 +10,28 @@ from neqsim.thermo import fluid
 from neqsim import jNeqSim
 from jpype import JImplements, JOverride
 
+
 class ExampleCompressor(unitop):
     def __init__(self):
         super().__init__()
         self.name = ""
         self.inputstream = None
         self.outputstream = None
-    
+
     def setInputStream(self, stream):
         self.inputstream = stream
         self.outputstream = stream.clone()
 
     def getOutputStream(self):
         return self.outputstream
-    
+
     @JOverride
     def run(self):
         fluid2 = self.inputstream.getFluid().clone()
-        fluid2.setPressure(fluid2.getPressure()*2.0)
+        fluid2.setPressure(fluid2.getPressure() * 2.0)
         self.outputstream.setFluid(fluid2)
         self.outputstream.run()
+
 
 def test_addPythonUnitOp():
     fluid1 = fluid("srk")  # create a fluid using the SRK-EoS
@@ -42,18 +44,19 @@ def test_addPythonUnitOp():
     stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)
     stream1.setFlowRate(30000, "kg/hr")
     stream1.run()
-    
+
     uop = ExampleCompressor()
-    uop.setName('example operation 1')
+    uop.setName("example operation 1")
     uop.setInputStream(stream1)
     uop.run()
 
-    stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(uop.getOutputStream())
+    stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(
+        uop.getOutputStream()
+    )
     stream2.run()
 
-    assert stream2.getPressure()==2*stream1.getPressure()
+    assert stream2.getPressure() == 2 * stream1.getPressure()
 
-    
     oilprocess = jNeqSim.processSimulation.processSystem.ProcessSystem()
     oilprocess.add(stream1)
     oilprocess.add(uop)
@@ -61,5 +64,4 @@ def test_addPythonUnitOp():
 
     oilprocess.run()
 
-    assert stream2.getPressure()==2*stream1.getPressure()
-
+    assert stream2.getPressure() == 2 * stream1.getPressure()

--- a/tests/process/test_unitop.py
+++ b/tests/process/test_unitop.py
@@ -1,0 +1,5 @@
+from neqsim.process.unitop import unitop
+
+def test_pump():
+    uop = unitop()
+    assert True


### PR DESCRIPTION
Framework for adding new unit operations in python code (for fast testing before full implementation in Java). See how to implement Java interfaces from Python:
https://jpype.readthedocs.io/en/latest/quickguide.html#implements-and-extension

Eg. given in test:
```

class ExampleCompressor(unitop):
    def __init__(self):
        super().__init__()
        self.name = ""
        self.inputstream = None
        self.outputstream = None

    def setInputStream(self, stream):
        self.inputstream = stream
        self.outputstream = stream.clone()

    def getOutputStream(self):
        return self.outputstream

    @JOverride
    def run(self):
        fluid2 = self.inputstream.getFluid().clone()
        fluid2.setPressure(fluid2.getPressure() * 2.0)
        self.outputstream.setFluid(fluid2)
        self.outputstream.run()
```



The code can be tested:
```

   fluid1 = fluid("srk")  # create a fluid using the SRK-EoS
    fluid1.setTemperature(30.0, "C")
    fluid1.setPressure(1.0, "bara")
    fluid1.addComponent("n-pentane", 1.0, "kg/sec")
    fluid1.addComponent("n-hexane", 1.0, "kg/sec")
    fluid1.setMixingRule(2)

    stream1 = jNeqSim.processSimulation.processEquipment.stream.Stream(fluid1)
    stream1.setFlowRate(30000, "kg/hr")
    stream1.run()
    
    uop = ExampleCompressor()
    uop.setName('example operation 1')
    uop.setInputStream(stream1)
    uop.run()

    stream2 = jNeqSim.processSimulation.processEquipment.stream.Stream(uop.getOutputStream())
    stream2.run()

    assert stream2.getPressure()==2*stream1.getPressure()
```


